### PR TITLE
Add search queries for Fortinet FortiSandbox

### DIFF
--- a/QUERIES.yaml
+++ b/QUERIES.yaml
@@ -34523,3 +34523,17 @@
     - platform: shodan
       queries:
         - http.title:"fortisandbox"
+
+- name: fortisandbox
+  vendor: fortinet
+  type: product
+  engines:
+    - platform: shodan
+      queries:
+        - title:"FortiSandbox"
+    - platform: fofa
+      queries:
+        - title="FortiSandbox"
+    - platform: censys
+      queries:
+        - services.http.response.html_title: "FortiSandbox"


### PR DESCRIPTION
# Add search queries for Fortinet FortiSandbox 

Added basic identification queries for Fortinet FortiSandbox appliances across multiple search engines:

- **Shodan:** `title:"FortiSandbox"`
- **FOFA:** `title="FortiSandbox"`
- **Censys:** `services.http.response.html_title: "FortiSandbox"`
